### PR TITLE
修复 TLS 验证配置冲突问题、添加命令行参数控制 TLS 验证

### DIFF
--- a/cmd/inspector/app/app.go
+++ b/cmd/inspector/app/app.go
@@ -11,7 +11,7 @@ import (
 
 func Run() {
 	var kubeconfig, namespace, token, server string
-	var skipCheckSensitiveField bool
+	var skipCheckSensitiveField, insecureSkipTLS bool
 
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	//flag.BoolVar(&skipNativeAPI, "skip-native-api", true, "")
@@ -19,9 +19,10 @@ func Run() {
 	flag.StringVar(&token, "token", "", "token for access apiserver. Only required if out-of-cluster.")
 	flag.StringVar(&server, "server", "", "target apiserver address.")
 	flag.BoolVar(&skipCheckSensitiveField, "skipCheckSensitiveField", false, "if true skip check resource sensitive field")
+	flag.BoolVar(&insecureSkipTLS, "insecure-skip-tls-verify", false, "if true, skip TLS verification for Kubernetes API server")
 	flag.Parse()
 
-	kubeClient, err := kubeclient.NewKubeClient(kubeconfig, namespace)
+	kubeClient, err := kubeclient.NewKubeClient(kubeconfig, namespace, insecureSkipTLS)
 	if err != nil {
 		fmt.Printf("[-] Failed to create kubeclient: %s\nmake sure kubeconfig is valided.", err)
 		return


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a1d035fc-d563-4326-9100-ed6c863840a1)
解决了在 master 节点上执行时出现的错误 "Failed to create kubeclient: failed to create kubeclient: specifying a root certificates file with the insecure flag is not allowed"。通过修改代码，确保只有在适当的情况下才跳过 TLS 验证。
添加了一个新的命令行标志 --insecure-skip-tls-verify，允许用户明确指定是否跳过 TLS 验证。